### PR TITLE
Remove overflow hidden from color card

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -459,7 +459,7 @@
     /* ── Color card ── */
     .ccard {
       border-radius: 8px; border: 1px solid var(--border);
-      background: var(--bg); overflow: hidden;
+      background: var(--bg);
     }
     .ccard-hdr {
       padding: 7px 12px;


### PR DESCRIPTION
## Description

Removes `overflow: hidden;` from the color cards (`.ccard`) so users can scroll through content if it exceeds the maximum height of the panel (`.panel`).

https://share.cleanshot.com/DQbgdWdT

## Steps To Test

1. With the extension installed and enabled, go to the [poe ninja skill gems page](https://poe.ninja/poe1/economy/keepers/skill-gems)
2. Open the chrome developer tools, toggle the device toolbar, then set the dimensions to 1728 × 1117px
	- (the height can actually be anything <= 1117px)
3. Set the "Top X gems per color" to `8`.